### PR TITLE
refactor!: rename namespace from hisorange to Pataar

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ if (Browser::isAndroid()) {
 ### Standalone (without Laravel)
 
 ```php
-use hisorange\BrowserDetect\Parser as Browser;
+use Pataar\BrowserDetect\Parser as Browser;
 
 if (Browser::isLinux()) {
     // Works without Laravel!
@@ -144,13 +144,13 @@ Results are cached in memory for the current request and optionally persisted vi
 In Laravel, publish the config file:
 
 ```sh
-php artisan vendor:publish --provider="hisorange\BrowserDetect\ServiceProvider"
+php artisan vendor:publish --provider="Pataar\BrowserDetect\ServiceProvider"
 ```
 
 In standalone mode, pass a custom config array:
 
 ```php
-use hisorange\BrowserDetect\Parser;
+use Pataar\BrowserDetect\Parser;
 
 $browser = new Parser(null, null, [
     'cache' => [

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "tablet",
     "user agent",
     "analyse",
-    "hisorange"
+    "pataar"
   ],
   "homepage": "https://github.com/pataar/browser-detect",
   "license": "MIT",
@@ -37,22 +37,22 @@
   },
   "autoload": {
     "psr-4": {
-      "hisorange\\BrowserDetect\\": "src/"
+      "Pataar\\BrowserDetect\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "hisorange\\BrowserDetect\\Test\\": "tests/"
+      "Pataar\\BrowserDetect\\Test\\": "tests/"
     }
   },
   "minimum-stability": "stable",
   "extra": {
     "laravel": {
       "providers": [
-        "hisorange\\BrowserDetect\\ServiceProvider"
+        "Pataar\\BrowserDetect\\ServiceProvider"
       ],
       "aliases": {
-        "Browser": "hisorange\\BrowserDetect\\Facade"
+        "Browser": "Pataar\\BrowserDetect\\Facade"
       }
     }
   },

--- a/src/Contracts/ParserInterface.php
+++ b/src/Contracts/ParserInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect\Contracts;
+namespace Pataar\BrowserDetect\Contracts;
 
 /**
  * Interface ParserInterface

--- a/src/Contracts/PayloadInterface.php
+++ b/src/Contracts/PayloadInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect\Contracts;
+namespace Pataar\BrowserDetect\Contracts;
 
 interface PayloadInterface
 {

--- a/src/Contracts/ResultInterface.php
+++ b/src/Contracts/ResultInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect\Contracts;
+namespace Pataar\BrowserDetect\Contracts;
 
 use JsonSerializable;
 

--- a/src/Contracts/StageInterface.php
+++ b/src/Contracts/StageInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect\Contracts;
+namespace Pataar\BrowserDetect\Contracts;
 
 interface StageInterface
 {

--- a/src/Exceptions/BadMethodCallException.php
+++ b/src/Exceptions/BadMethodCallException.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace hisorange\BrowserDetect\Exceptions;
+namespace Pataar\BrowserDetect\Exceptions;
 
 class BadMethodCallException extends Exception {}

--- a/src/Exceptions/Exception.php
+++ b/src/Exceptions/Exception.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace hisorange\BrowserDetect\Exceptions;
+namespace Pataar\BrowserDetect\Exceptions;
 
 class Exception extends \Exception {}

--- a/src/Facade.php
+++ b/src/Facade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect;
+namespace Pataar\BrowserDetect;
 
 use Illuminate\Support\Facades\Facade as BaseFacade;
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace hisorange\BrowserDetect;
+namespace Pataar\BrowserDetect;
 
-use hisorange\BrowserDetect\Contracts\ParserInterface;
-use hisorange\BrowserDetect\Contracts\ResultInterface;
-use hisorange\BrowserDetect\Contracts\StageInterface;
-use hisorange\BrowserDetect\Exceptions\BadMethodCallException;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Http\Request;
+use Pataar\BrowserDetect\Contracts\ParserInterface;
+use Pataar\BrowserDetect\Contracts\ResultInterface;
+use Pataar\BrowserDetect\Contracts\StageInterface;
+use Pataar\BrowserDetect\Exceptions\BadMethodCallException;
 
 /**
  * Manages the parsing mechanism.

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace hisorange\BrowserDetect;
+namespace Pataar\BrowserDetect;
 
-use hisorange\BrowserDetect\Contracts\PayloadInterface;
+use Pataar\BrowserDetect\Contracts\PayloadInterface;
 
 /**
  * This class is passed down in the pipeline,

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace hisorange\BrowserDetect;
+namespace Pataar\BrowserDetect;
 
-use hisorange\BrowserDetect\Contracts\ResultInterface;
+use Pataar\BrowserDetect\Contracts\ResultInterface;
 
 /**
  * The object is used for safely accessing the

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect;
+namespace Pataar\BrowserDetect;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Config\Repository as ConfigRepository;

--- a/src/Stages/BrowserDetect.php
+++ b/src/Stages/BrowserDetect.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace hisorange\BrowserDetect\Stages;
+namespace Pataar\BrowserDetect\Stages;
 
-use hisorange\BrowserDetect\Contracts\PayloadInterface;
-use hisorange\BrowserDetect\Contracts\StageInterface;
+use Pataar\BrowserDetect\Contracts\PayloadInterface;
+use Pataar\BrowserDetect\Contracts\StageInterface;
 
 /**
  * BrowserDetect stage to fix mix ups caused by different results.

--- a/src/Stages/CrawlerDetect.php
+++ b/src/Stages/CrawlerDetect.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace hisorange\BrowserDetect\Stages;
+namespace Pataar\BrowserDetect\Stages;
 
-use hisorange\BrowserDetect\Contracts\PayloadInterface;
-use hisorange\BrowserDetect\Contracts\StageInterface;
+use Pataar\BrowserDetect\Contracts\PayloadInterface;
+use Pataar\BrowserDetect\Contracts\StageInterface;
 
 /**
  * Checks if the user agent belongs to bot or crawler.

--- a/src/Stages/DeviceDetector.php
+++ b/src/Stages/DeviceDetector.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace hisorange\BrowserDetect\Stages;
+namespace Pataar\BrowserDetect\Stages;
 
 use DeviceDetector\Parser\Device\AbstractDeviceParser;
-use hisorange\BrowserDetect\Contracts\PayloadInterface;
-use hisorange\BrowserDetect\Contracts\StageInterface;
+use Pataar\BrowserDetect\Contracts\PayloadInterface;
+use Pataar\BrowserDetect\Contracts\StageInterface;
 
 /**
  * Strong browser and platform detector.

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
 use Illuminate\Support\Facades\Blade;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Class BladeTest
  *
- * @coversDefaultClass \hisorange\BrowserDetect\ServiceProvider
+ * @coversDefaultClass \Pataar\BrowserDetect\ServiceProvider
  */
 class BladeTest extends TestCase
 {

--- a/tests/FacadeTest.php
+++ b/tests/FacadeTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
-use hisorange\BrowserDetect\Contracts\ParserInterface;
-use hisorange\BrowserDetect\Facade;
+use Pataar\BrowserDetect\Contracts\ParserInterface;
+use Pataar\BrowserDetect\Facade;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Exception;
 
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Exception;
 class FacadeTest extends TestCase
 {
     /**
-     * @covers \hisorange\BrowserDetect\Facade
+     * @covers \Pataar\BrowserDetect\Facade
      *
      * @throws \PHPUnit_Framework_AssertionFailedError
      * @throws AssertionFailedError

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
-use hisorange\BrowserDetect\Contracts\ParserInterface;
-use hisorange\BrowserDetect\Contracts\ResultInterface;
-use hisorange\BrowserDetect\Exceptions\BadMethodCallException;
-use hisorange\BrowserDetect\Parser;
 use Illuminate\Http\Request;
+use Pataar\BrowserDetect\Contracts\ParserInterface;
+use Pataar\BrowserDetect\Contracts\ResultInterface;
+use Pataar\BrowserDetect\Exceptions\BadMethodCallException;
+use Pataar\BrowserDetect\Parser;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Exception;
@@ -14,7 +14,7 @@ use PHPUnit\Framework\Exception;
 /**
  * Class ParserTest
  *
- * @coversDefaultClass hisorange\BrowserDetect\Parser
+ * @coversDefaultClass Pataar\BrowserDetect\Parser
  */
 class ParserTest extends TestCase
 {

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
-use hisorange\BrowserDetect\Payload;
+use Pataar\BrowserDetect\Payload;
 
 /**
  * Class PayloadTest
  *
- * @coversDefaultClass hisorange\BrowserDetect\Payload
+ * @coversDefaultClass Pataar\BrowserDetect\Payload
  */
 class PayloadTest extends TestCase
 {

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
-use hisorange\BrowserDetect\Contracts\ResultInterface;
-use hisorange\BrowserDetect\Result;
+use Pataar\BrowserDetect\Contracts\ResultInterface;
+use Pataar\BrowserDetect\Result;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Exception;
 
 /**
  * Class ResultTest
  *
- * @coversDefaultClass hisorange\BrowserDetect\Result
+ * @coversDefaultClass Pataar\BrowserDetect\Result
  */
 class ResultTest extends TestCase
 {

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
-use hisorange\BrowserDetect\Contracts\ParserInterface;
+use Pataar\BrowserDetect\Contracts\ParserInterface;
 use PHPUnit\Framework\Exception;
 
 /**
  * Class ServiceProviderTest
  *
- * @coversDefaultClass hisorange\BrowserDetect\ServiceProvider
+ * @coversDefaultClass Pataar\BrowserDetect\ServiceProvider
  */
 class ServiceProviderTest extends TestCase
 {

--- a/tests/Stages/BrowserDetectTest.php
+++ b/tests/Stages/BrowserDetectTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test\Stages;
+namespace Pataar\BrowserDetect\Test\Stages;
 
-use hisorange\BrowserDetect\Contracts\ResultInterface;
-use hisorange\BrowserDetect\Payload;
-use hisorange\BrowserDetect\Result;
-use hisorange\BrowserDetect\Stages\BrowserDetect;
-use hisorange\BrowserDetect\Test\TestCase;
+use Pataar\BrowserDetect\Contracts\ResultInterface;
+use Pataar\BrowserDetect\Payload;
+use Pataar\BrowserDetect\Result;
+use Pataar\BrowserDetect\Stages\BrowserDetect;
+use Pataar\BrowserDetect\Test\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -15,7 +15,7 @@ use SebastianBergmann\RecursionContext\InvalidArgumentException;
 /**
  * Test the BrowserDetect stage.
  *
- * @coversDefaultClass hisorange\BrowserDetect\Stages\BrowserDetect
+ * @coversDefaultClass Pataar\BrowserDetect\Stages\BrowserDetect
  */
 class BrowserDetectTest extends TestCase
 {

--- a/tests/Stages/CrawlerDetectTest.php
+++ b/tests/Stages/CrawlerDetectTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test\Stages;
+namespace Pataar\BrowserDetect\Test\Stages;
 
-use hisorange\BrowserDetect\Payload;
-use hisorange\BrowserDetect\Stages\CrawlerDetect;
-use hisorange\BrowserDetect\Test\TestCase;
+use Pataar\BrowserDetect\Payload;
+use Pataar\BrowserDetect\Stages\CrawlerDetect;
+use Pataar\BrowserDetect\Test\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test the CrawlerDetect stage.
  *
- * @coversDefaultClass hisorange\BrowserDetect\Stages\CrawlerDetect
+ * @coversDefaultClass Pataar\BrowserDetect\Stages\CrawlerDetect
  */
 class CrawlerDetectTest extends TestCase
 {

--- a/tests/Stages/DeviceDetectorTest.php
+++ b/tests/Stages/DeviceDetectorTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test\Stages;
+namespace Pataar\BrowserDetect\Test\Stages;
 
-use hisorange\BrowserDetect\Payload;
-use hisorange\BrowserDetect\Stages\DeviceDetector;
-use hisorange\BrowserDetect\Test\TestCase;
+use Pataar\BrowserDetect\Payload;
+use Pataar\BrowserDetect\Stages\DeviceDetector;
+use Pataar\BrowserDetect\Test\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test the DeviceDetector stage.
  *
- * @coversDefaultClass hisorange\BrowserDetect\Stages\DeviceDetector
+ * @coversDefaultClass Pataar\BrowserDetect\Stages\DeviceDetector
  */
 class DeviceDetectorTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace hisorange\BrowserDetect\Test;
+namespace Pataar\BrowserDetect\Test;
 
-use hisorange\BrowserDetect\Facade;
-use hisorange\BrowserDetect\ServiceProvider;
 use Illuminate\Foundation\Application;
+use Pataar\BrowserDetect\Facade;
+use Pataar\BrowserDetect\ServiceProvider;
 
 /**
  * Base test case for the package tests.


### PR DESCRIPTION
## Summary

- Renames root namespace from `hisorange\BrowserDetect` to `Pataar\BrowserDetect` across all source, test, and config files
- Updates PSR-4 autoload mappings, Laravel auto-discovery config, and README code examples
- Keeps original author attribution (composer.json author, README credits, historical issue links)
- Adds UPGRADING.md documenting the breaking change with a cross-platform migration one-liner

## Checklist

- [x] `composer test` passes
- [x] `composer analyse` passes (PHPStan level max, zero errors)
- [x] Test coverage remains at 100%
- [x] New detection methods have integration tests with real user agent strings
- [x] New boolean flags include exclusivity assertions (setting one flag doesn't trigger unrelated flags)

## Test plan

- [x] All 79 tests pass after namespace rename
- [x] PHPStan level max, 0 errors
- [x] Verified only attribution references to `hisorange` remain (author email, GitHub links, credits)