### PR TITLE
ci: harden workflows with concurrency, timeouts, and pinned actions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,33 +11,29 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: 8.4
+          php-version: 8.3
           coverage: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-phpstan-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-phpstan-composer-
-
       - name: Install dependencies
-        run: composer install --no-interaction
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        with:
+          custom-cache-suffix: phpstan
 
       - name: Run PHPStan
         run: composer analyse
@@ -45,29 +41,21 @@ jobs:
   pint:
     name: Pint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.4
           coverage: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-pint-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-pint-composer-
-
       - name: Install dependencies
-        run: composer install --no-interaction
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        with:
+          custom-cache-suffix: pint
 
       - name: Run Pint
         run: composer lint -- --test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: PHPUnit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -27,36 +32,28 @@ jobs:
             coverage: true
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.laravel-version }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.laravel-version }}-${{ matrix.php-version }}-composer-
 
       - name: Lock laravel/framework version
         run: composer require laravel/framework:${{ matrix.laravel-version }} --no-update
 
       - name: Install dependencies
-        run: composer update --no-interaction
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+        with:
+          dependency-versions: highest
+          custom-cache-suffix: ${{ matrix.php-version }}-${{ matrix.laravel-version }}
 
       - name: Run test suites
         run: composer run-script ${{ matrix.coverage && 'test-with-coverage' || 'test' }}
 
       - name: Upload coverage to Coveralls
         if: matrix.coverage
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           file: build/logs/clover.xml


### PR DESCRIPTION
## Summary

Hardens both GitHub Actions workflows (`tests.yml`, `static-analysis.yml`) for supply-chain safety and CI efficiency.

- **Concurrency** — superseded PR runs are now cancelled (`cancel-in-progress` gated to `pull_request` events, so post-merge runs on `main`/`6.x` still complete). Key uses `head_ref || ref` so a PR's `push` + `pull_request` events share one group.
- **Timeouts** — `timeout-minutes: 15` on every job to backstop hung runs.
- **Caching refactor** — the repeated 3-step composer-cache dance replaced with `ramsey/composer-install`. Tests keep the `composer require ... --no-update` step and use `dependency-versions: highest` for the Laravel matrix; `custom-cache-suffix` isolates caches per matrix entry.
- **SHA-pinned actions** — all four actions pinned to immutable commit SHAs with `# version` comments. Dependabot maintains these going forward (no config change needed).
- **PHPStan on PHP 8.3** — analysis now runs on the lowest supported version (was 8.4) to catch floor-version issues.

## Pinned actions

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v6.0.3 | `9f698171` |
| `shivammathur/setup-php` | 2.37.2 | `f3e473d1` |
| `ramsey/composer-install` | 3.2.1 | `a8d0d959` |
| `coverallsapp/github-action` | v2.3.7 | `5cbfd81b` |

## Test plan

- YAML validated for both workflows.
- CI on this PR exercises the refactored caching + concurrency end-to-end.

## Note

`6.x` still appears in the `push` triggers — flagging in case that branch is stale and the reference should be dropped.